### PR TITLE
Task: Cover a Mare (With A Public Covering Offer)

### DIFF
--- a/tasks/t_cover_mare.dita
+++ b/tasks/t_cover_mare.dita
@@ -6,6 +6,34 @@
     Players can breed a mare that is at least 2 years and 6 months of age by accepting a covering offer.
   </shortdesc>
   <taskbody>
-
+    <steps>
+      <step>
+        <cmd>Navigate to a mare's private page in your breeding farm.</cmd>
+      </step>
+      <step>
+        <cmd>Find the Breeding tile on your mare's page.</cmd>
+        <cmd>Select Cover my mare.</cmd>
+        <stepresult>The public coverings search page displays.</stepresult>
+      </step>
+      <step>
+        <cmd>Use the available filter feature to apply specific criteria to your search.</cmd>
+        <cmd>Select Display coverings.</cmd>
+      </step>
+      <step>
+        <cmd>Pick the public covering offer you'd like to accept.</cmd>
+        <cmd>Select Choose.</cmd>
+        <stepresult>A confirmation page displays that allows you to preview the genetic details of the stallion before accepting the covering.</stepresult>
+      </step>
+      <step>
+        <cmd>Confirm that the genetic details for both the sire and dam you are attempting to breed align with your desired traits.</cmd>
+      </step>
+      <step>
+        <cmd>If desired, apply items from the Black Market to your mare to enhance the gestation period or the foals she gives birth to.</cmd>
+        <info>Items display on the right-hand side of the window. To apply an item to the covering, select Use.</info>
+      </step>
+      <step>
+        <cmd>Select Cover my mare.</cmd>
+      </step>
+    </steps>
   </taskbody>
 </task>

--- a/tasks/t_cover_mare.dita
+++ b/tasks/t_cover_mare.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
 <task id="t_cover_mare">
-  <title>Cover a Mare</title>
+  <title>Cover a Mare with a Public Covering Offer</title>
   <shortdesc>
     Players can breed a mare that is at least 2 years and 6 months of age by accepting a covering offer.
   </shortdesc>

--- a/tasks/t_cover_mare.dita
+++ b/tasks/t_cover_mare.dita
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
+<task id="t_cover_mare">
+  <title>Cover a Mare</title>
+  <shortdesc>
+    Players can breed a mare that is at least 2 years and 6 months of age by accepting a covering offer.
+  </shortdesc>
+  <taskbody>
+
+  </taskbody>
+</task>


### PR DESCRIPTION
## Topic Information
Task Topic: Cover a Mare
File Name: t_cover_a_mare

## Brief Description
This task topic describes how to cover a mare with a public covering offer. It does not cover private covering offers, although it might be worth including that in our topic model.

## Requested Feedback
@kb-boop - How do we feel about the title I've given this topic? Do you think I need to make it "Cover a Mare With a Public Covering Offer," or can it be left as just "Cover a Mare"? Additionally, do you think it would be beneficial to add a task topic about how to cover a mare with a _private_ covering offer?